### PR TITLE
 ヘッダーの名前押下時のドロップダウンメニューが外側クリックで閉じない問題を修正しました。

### DIFF
--- a/frontend/components/layouts/Header.vue
+++ b/frontend/components/layouts/Header.vue
@@ -10,12 +10,14 @@ const userStore = useUserStore();
 const csrfTokenStore = useCsrfTokenStore();
 
 const isDropdownVisible = ref(false);
+const dropdownRef = ref<HTMLElement | null>(null);
 const isLogged = computed(() => userStore.isLogged);
 
 const handleLogout = async () => {
   await logoutService();
   userStore.resetUser();
   csrfTokenStore.resetCsrfToken();
+  isDropdownVisible.value = false;
 };
 
 const handleLogin = () => {
@@ -28,7 +30,26 @@ const handleDropdown = () => {
 
 const handleGoToCart = () => {
   router.push("/cart");
+  isDropdownVisible.value = false;
 };
+
+const closeDropdown = () => {
+  isDropdownVisible.value = false;
+};
+
+const handleClickOutside = (event: Event) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target as Node)) {
+    closeDropdown();
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside);
+});
 </script>
 
 <template>
@@ -40,6 +61,7 @@ const handleGoToCart = () => {
       <ul class="nav__list">
         <li
           class="nav__item nav__dropdown-wrapper"
+          ref="dropdownRef"
           @click.prevent="handleDropdown"
         >
           <span class="nav__toggle">{{


### PR DESCRIPTION
 ## 変更内容
  - **外側クリック検知機能を追加**: `handleClickOutside`関数でドロップダウン外部のクリックを検知
  - **イベントリスナー管理**: `onMounted`/`onUnmounted`で適切にリスナーを設定/削除
  - **UX改善**: メニュー項目選択時にもドロップダウンが閉じるよう改善
  - **メモリリーク防止**: コンポーネントアンマウント時のクリーンアップを実装

  ## 修正ファイル
  - `frontend/components/layouts/Header.vue`

  ## テスト
  - TypeScriptビルド正常完了 ✅

  ## 関連Issue
  Fixes #1