### PR TITLE
Chrome入力欄黒表示問題の修正とフォームバリデーション最適化

### DIFF
--- a/frontend/components/cart/PaymentModal.vue
+++ b/frontend/components/cart/PaymentModal.vue
@@ -135,4 +135,23 @@ onUnmounted(() => {
   border-radius: 4px;
   cursor: pointer;
 }
+
+/* 決済フォーム入力欄のChrome autofill/ダークモード対応 */
+input[type="text"] {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  /* ダークモード対応 */
+  color-scheme: light;
+  background-color: white;
+  color: black;
+}
+
+/* Chrome autofill対応 */
+input[type="text"]:-webkit-autofill,
+input[type="text"]:-webkit-autofill:hover,
+input[type="text"]:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 30px white inset !important;
+  -webkit-text-fill-color: black !important;
+}
 </style>

--- a/frontend/components/common/TextInput.vue
+++ b/frontend/components/common/TextInput.vue
@@ -32,5 +32,17 @@ input {
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
+  /* ダークモード対応 */
+  color-scheme: light;
+  background-color: white;
+  color: black;
+}
+
+/* Chrome autofill対応 */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 30px white inset !important;
+  -webkit-text-fill-color: black !important;
 }
 </style>

--- a/frontend/components/pages/contact/TextField.vue
+++ b/frontend/components/pages/contact/TextField.vue
@@ -53,6 +53,18 @@ const handleInput = (event: any) => {
   border: none;
   border-bottom: 1px solid #dadce0;
   width: 300px;
+  /* ダークモード対応 */
+  color-scheme: light;
+  background-color: white;
+  color: black;
+}
+
+/* Chrome autofill対応 */
+.input:-webkit-autofill,
+.input:-webkit-autofill:hover,
+.input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 30px white inset !important;
+  -webkit-text-fill-color: black !important;
 }
 .input:focus {
   border: 1px solid lightblue;

--- a/frontend/pages/contact.vue
+++ b/frontend/pages/contact.vue
@@ -12,9 +12,20 @@ const loadingStore = useLoadingStore();
 
 const schema = toTypedSchema(
   z.object({
-    name: z.string().min(1, { message: "Field is required" }),
-    email: z.string().min(1, { message: "Field is required" }),
-    gender: z.number().nullable(),
+    name: z
+      .string()
+      .min(1, { message: "お名前は必須です" })
+      .max(50, { message: "お名前は50文字以内で入力してください" })
+      .regex(/^[^\s].*[^\s]$|^[^\s]$/, { message: "お名前の前後に空白は使用できません" }),
+    email: z
+      .string()
+      .min(1, { message: "メールアドレスは必須です" })
+      .email({ message: "正しいメールアドレスを入力してください" })
+      .max(255, { message: "メールアドレスは255文字以内で入力してください" }),
+    gender: z
+      .number({ message: "性別を選択してください" })
+      .min(0, { message: "性別を選択してください" })
+      .max(1, { message: "正しい性別を選択してください" }),
   })
 );
 
@@ -23,7 +34,7 @@ const { errors, defineField, handleSubmit } = useForm({
   initialValues: {
     name: "",
     email: "",
-    gender: null,
+    gender: undefined,
   },
 });
 const [name, nameProps] = defineField("name");

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -16,8 +16,16 @@ const loadingStore = useLoadingStore();
 
 const schema = toTypedSchema(
   z.object({
-    email: z.string().min(1, { message: "Field is required" }),
-    password: z.string().min(1, { message: "Field is required" }),
+    email: z
+      .string()
+      .min(1, { message: "メールアドレスは必須です" })
+      .email({ message: "正しいメールアドレスを入力してください" })
+      .max(255, { message: "メールアドレスは255文字以内で入力してください" }),
+    password: z
+      .string()
+      .min(1, { message: "パスワードは必須です" })
+      .min(6, { message: "パスワードは6文字以上で入力してください" })
+      .max(255, { message: "パスワードは255文字以内で入力してください" }),
   })
 );
 const { errors, defineField, handleSubmit } = useForm({


### PR DESCRIPTION
## 概要

Chrome閲覧時にフォーム入力欄が黒く表示される問題（Issue #3）を修正し、フォームバリデーションを最適化しました。

## 修正内容

### Chrome autofill/ダークモード対応
- **TextInput.vue**: ログイン・会員登録フォームの入力欄
- **TextField.vue**: お問い合わせフォームの入力欄
- **PaymentModal.vue**: 決済フォームの入力欄

各コンポーネントに以下のCSSを追加：
```css
/* ダークモード対応 */
color-scheme: light;
background-color: white;
color: black;

/* Chrome autofill対応 */
input:-webkit-autofill,
input:-webkit-autofill:hover,
input:-webkit-autofill:focus {
  -webkit-box-shadow: 0 0 0 30px white inset !important;
  -webkit-text-fill-color: black !important;
}
```

### フォームバリデーション最適化

#### login.vue
- メールアドレス形式チェック追加
- パスワード最小6文字チェック追加
- 文字数制限追加（255文字）
- 日本語エラーメッセージ導入

#### contact.vue
- 名前の前後空白チェック追加
- メールアドレス形式チェック追加
- 性別選択の範囲修正（0-1に変更）
- 文字数制限追加
- 日本語エラーメッセージ導入

## テスト確認項目

- [ ] Chromeでログインフォームの入力欄が正常に表示される
- [ ] Chromeでお問い合わせフォームの入力欄が正常に表示される  
- [ ] Chromeで決済フォームの入力欄が正常に表示される
- [ ] 各フォームでバリデーションエラーが適切に日本語で表示される
- [ ] 性別選択で男性・女性両方が正常に選択できる

## 関連Issue

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)